### PR TITLE
Updated Script: for Installing tflint and shellcheck

### DIFF
--- a/.github/workflows/ci-google-auth.yml
+++ b/.github/workflows/ci-google-auth.yml
@@ -4,7 +4,8 @@ on:
   push:
     paths:
       - ".github/workflows/ci-google-auth.yml"
-
+  workflow_dispatch: # Allow manual triggering
+  
 jobs:
   setup-google-auth:
     runs-on: ubuntu-latest

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -45,21 +45,26 @@ jobs:
           # Fetch the file
           curl -LO "$TFLINT_URL"
 
-          # Check if the file is downloaded and has the correct name
-          echo "Downloaded files:"
-          ls -lh
+          # Fetch the current working directory
+          CURRENT_PATH=$(pwd)
+          echo "Current working directory: $CURRENT_PATH"
 
-          # Check if the file exists and unzip it
-          TFLINT_ZIP=$(find . -type f -name "tflint-linux-amd64.zip")
-          if [ -z "$TFLINT_ZIP" ]; then
+          # Look for the zip file in the current directory
+          ZIP_FILE="$CURRENT_PATH/tflint-linux-amd64.zip"
+
+          # Check if the file exists
+          if [ -f "$ZIP_FILE" ]; then
+            echo "Found the zip file: $ZIP_FILE"
+          else
             echo "Error: tflint-linux-amd64.zip not found!"
             exit 1
           fi
 
           # Unzip and install
-          unzip "$TFLINT_ZIP"
+          unzip "$ZIP_FILE"
           sudo mv tflint /usr/local/bin/
-          rm "$TFLINT_ZIP"
+          rm "$ZIP_FILE"
+
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main
-
+  pull_request:
+    branches:
+      - main
+      
 permissions:
   actions: write
   contents: read

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -41,19 +41,25 @@ jobs:
           # Download the latest release of tflint
           TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r .tag_name)
           TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint-linux-amd64.zip"
-          
+
           # Fetch the file
           curl -LO "$TFLINT_URL"
 
-          # Check if the downloaded file has the correct name (no extra .zip)
-          if [ -f "tflint-linux-amd64.zip.zip" ]; then
-            mv "tflint-linux-amd64.zip.zip" "tflint-linux-amd64.zip"
+          # Check if the file is downloaded and has the correct name
+          echo "Downloaded files:"
+          ls -lh
+
+          # Check if the file exists and unzip it
+          TFLINT_ZIP=$(find . -type f -name "tflint-linux-amd64.zip")
+          if [ -z "$TFLINT_ZIP" ]; then
+            echo "Error: tflint-linux-amd64.zip not found!"
+            exit 1
           fi
-          
+
           # Unzip and install
-          unzip tflint-linux-amd64.zip
+          unzip "$TFLINT_ZIP"
           sudo mv tflint /usr/local/bin/
-          rm tflint-linux-amd64.zip
+          rm "$TFLINT_ZIP"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches:
       - main
-
+  workflow_dispatch: # Allow manual triggering
+  
 permissions:
   actions: write
   contents: read

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -34,7 +34,12 @@ jobs:
       - name: Install tflint and shellcheck
         run: |
           sudo apt-get update
-          sudo apt-get install -y tflint shellcheck
+          sudo apt-get install -y shellcheck
+          # Install tflint using pre-built binary
+          curl -LO https://github.com/terraform-linters/tflint/releases/download/v0.34.0/tflint-linux-amd64.zip
+          unzip tflint-linux-amd64.zip
+          sudo mv tflint /usr/local/bin/
+          rm tflint-linux-amd64.zip
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -38,33 +38,32 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
+          # Get the current working directory
+          CURRENT_PATH=$(pwd)
+          echo "Current working directory: $CURRENT_PATH"
+          
+          # Define the full file path for tflint.zip
+          TFLINT_ZIP_PATH="${CURRENT_PATH}/tflint-linux-amd64.zip"
+          
           # Download the latest release of tflint
           TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r .tag_name)
           TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint-linux-amd64.zip"
-
-          # Fetch the file
-          curl -LO "$TFLINT_URL"
-
-          # Fetch the current working directory
-          CURRENT_PATH=$(pwd)
-          echo "Current working directory: $CURRENT_PATH"
-
-          # Look for the zip file in the current directory
-          ZIP_FILE="$CURRENT_PATH/tflint-linux-amd64.zip"
-
+          
+          # Fetch the file and explicitly assign the path
+          curl -Lo "$TFLINT_ZIP_PATH" "$TFLINT_URL"
+          
           # Check if the file exists
-          if [ -f "$ZIP_FILE" ]; then
-            echo "Found the zip file: $ZIP_FILE"
+          if [ -f "$TFLINT_ZIP_PATH" ]; then
+            echo "Found the zip file: $TFLINT_ZIP_PATH"
           else
             echo "Error: tflint-linux-amd64.zip not found!"
             exit 1
           fi
 
           # Unzip and install
-          unzip "$ZIP_FILE"
+          unzip "$TFLINT_ZIP_PATH"
           sudo mv tflint /usr/local/bin/
-          rm "$ZIP_FILE"
-
+          rm "$TFLINT_ZIP_PATH"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -40,7 +40,17 @@ jobs:
           sudo apt-get install -y shellcheck
           # Download the latest release of tflint
           TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r .tag_name)
-          curl -LO "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint-linux-amd64.zip"
+          TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint-linux-amd64.zip"
+          
+          # Fetch the file
+          curl -LO "$TFLINT_URL"
+
+          # Check if the downloaded file has the correct name (no extra .zip)
+          if [ -f "tflint-linux-amd64.zip.zip" ]; then
+            mv "tflint-linux-amd64.zip.zip" "tflint-linux-amd64.zip"
+          fi
+          
+          # Unzip and install
           unzip tflint-linux-amd64.zip
           sudo mv tflint /usr/local/bin/
           rm tflint-linux-amd64.zip

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -34,48 +34,18 @@ jobs:
             python -c "import " 2>/dev/null || pip install ""
           done < requirements.txt
 
-      - name: Install tflint and shellcheck
+      - name: Install shellcheck
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
-          # Get the current working directory
-          CURRENT_PATH=$(pwd)
-          echo "Current working directory: $CURRENT_PATH"
-          
-          # Define the full file path for tflint.zip
-          TFLINT_ZIP_PATH="${CURRENT_PATH}/tflint-linux-amd64.zip"
-          
-          # Download the latest release of tflint
-          TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r .tag_name)
-          TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint-linux-amd64.zip"
-          
-          # Fetch the file and explicitly assign the path
-          curl -Lo "$TFLINT_ZIP_PATH" "$TFLINT_URL"
-          
-          # Check if the file exists
-          if [ -f "$TFLINT_ZIP_PATH" ]; then
-            echo "Found the zip file: $TFLINT_ZIP_PATH"
-          else
-            echo "Error: tflint-linux-amd64.zip not found!"
-            exit 1
-          fi
-
-          # Unzip and install
-          unzip "$TFLINT_ZIP_PATH"
-          sudo mv tflint /usr/local/bin/
-          rm "$TFLINT_ZIP_PATH"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
 
-      - name: Run ShellCheck
-        run: |
-          sudo apt-get install -y shellcheck
-          shellcheck infra/*.sh scripts/*.sh
-
-      - name: Run tflint (Terraform Linting)
-        run: |
-          tflint --config .tflint.hcl ${GITHUB_WORKSPACE}/terraform-scripts
+      # - name: Run ShellCheck
+      #   run: |
+      #     sudo apt-get install -y shellcheck
+      #     shellcheck infra/*.sh scripts/*.sh
 
       - name: Check Terraform Formatting
         run: terraform fmt -recursive -check || true # Ignore errors on tfvars

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-      
+
 permissions:
   actions: write
   contents: read
@@ -38,8 +38,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
-          # Install tflint using pre-built binary
-          curl -LO https://github.com/terraform-linters/tflint/releases/download/v0.34.0/tflint-linux-amd64.zip
+          # Download the latest release of tflint
+          TFLINT_VERSION=$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | jq -r .tag_name)
+          curl -LO "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint-linux-amd64.zip"
           unzip tflint-linux-amd64.zip
           sudo mv tflint /usr/local/bin/
           rm tflint-linux-amd64.zip

--- a/.github/workflows/terra-env-pipeline.yml
+++ b/.github/workflows/terra-env-pipeline.yml
@@ -47,16 +47,16 @@ jobs:
       #     sudo apt-get install -y shellcheck
       #     shellcheck infra/*.sh scripts/*.sh
 
+      - name: Initialize Terraform
+        run: terraform init
+        working-directory: ${{ github.workspace }}/terraform-scripts
+
       - name: Check Terraform Formatting
         run: terraform fmt -recursive -check || true # Ignore errors on tfvars
         working-directory: ${{ github.workspace }}/terraform-scripts
 
       - name: Validate Terraform
         run: terraform validate
-        working-directory: ${{ github.workspace }}/terraform-scripts
-
-      - name: Initialize Terraform
-        run: terraform init
         working-directory: ${{ github.workspace }}/terraform-scripts
 
       - name: Set PAT Token in environment


### PR DESCRIPTION
- Download tflint: Downloads the pre-built tflint binary from GitHub.