### PR TITLE
FIX: Action path at middle-stream

### DIFF
--- a/.github/actions/request-api-service/action.yml
+++ b/.github/actions/request-api-service/action.yml
@@ -23,13 +23,13 @@ runs:
         project_id: ${{ inputs.gcp_project_id }}
 
     - name: Google Cloud Authentication
-      uses: ./.github/actions/google-auth
+      uses: .github/actions/google-auth
       with:
         GCP_SA_KEY: ${{ inputs.access_key }}
         GCP_PROJECT: ${{ inputs.gcp_project_id }}
 
     - name: Enable API Service
-      uses: ./.github/actions/enable-api-service
+      uses: .github/actions/enable-api-service
       with:
         gcp_project_id: ${{ inputs.gcp_project_id }}
         api_service: ${{ inputs.api_service }}


### PR DESCRIPTION
- when triggering from a workflow (triggering action from a workflow) you explicitly have to indicate "./.github/actions/....."
- when the same code added to composite action (triggering action from action) you need to remove ./

e.g. ".github/actions/...."