### PR TITLE
fix: artifact v4

### DIFF
--- a/.github/actions/google-auth/action.yml
+++ b/.github/actions/google-auth/action.yml
@@ -20,20 +20,14 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-   - name: Download GCP Service Account Key Artifact
-      uses: actions/download-artifact@v3
+    - name: Download GCP Service Account Key Artifact
+      uses: actions/download-artifact@v4
       with:
         name: create-instance-gcp-key
 
-    - name: Print the downloaded file's full path
-      run: |
-        # Find the downloaded artifact directory
-        artifact_dir=$(find . -name 'gcp-key.json' -type f)
-        echo "The downloaded GCP service account key is located at: $artifact_dir"
-    
     - name: Authenticate with GCP
       run: |
-        gcloud auth activate-service-account --key-file=gcp-key.json
+        gcloud auth activate-service-account --key-file=./gcp-key.json
 
     # - name: Authenticate with Google Cloud
     #   shell: bash

--- a/.github/workflows/activate-compute-api.yml
+++ b/.github/workflows/activate-compute-api.yml
@@ -13,11 +13,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Write GCP Service Account Key to File
+        shell: bash
+        run: |
+          echo "${{ secrets.GCP_SA_KEY }}" | jq '.' > /tmp/gcp-key.json
+          
       - name: Upload GCP Service Account Key as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: create-instance-gcp-key
-          path: ${{ secrets.GCP_SA_KEY }}
+          path: /tmp/gcp-key.json
 
       - name: Trigger Enable API Service Workflow
         run: |


### PR DESCRIPTION
- v3 has been depreciated. using v4.
- write a secret to the file and then upload it to artifact instead of uploading the secret (json object) as an artifact. LoL ChatGPT is not 100% reliable.